### PR TITLE
add note that partialUpdate() only works in monochrome mode

### DIFF
--- a/source/arduino.rst
+++ b/source/arduino.rst
@@ -387,7 +387,7 @@ Inkplate::partialUpdate();
     Returns nothing.
 
 * **Description**:
-    | Updates only the changed parts of the screen.
+    | Updates only the changed parts of the screen. (monochrome/INKPLATE_1BIT mode only!)
     | After a few updates creates blurry parts of the screen.
     | Fixed by calling Inkplate::clean();
 


### PR DESCRIPTION
This PR adds a note to `partialUpdate()` that it only works in monochrome mode.