### PR TITLE
 setTextColor()

### DIFF
--- a/source/arduino.rst
+++ b/source/arduino.rst
@@ -2175,7 +2175,7 @@ Inkplate::print();
 
 * **Example**:
     .. code-block:: c
-
+	display.setTextColor(BLACK, WHITE);
         display.print("Some text");
 
 * **Result**:
@@ -2207,7 +2207,7 @@ Inkplate::println();
 
 * **Example**:
     .. code-block:: c
-    
+    	display.setTextColor(BLACK, WHITE);
         display.println("Some text");
 
 


### PR DESCRIPTION
Add the display.setTextColor(BLACK, WHITE); function call to the print() and println() examples. 
Like stated  in #9  setTextColor() is part of the Adafruit GFX. However adding this line to the example can save more than one from a small headache.